### PR TITLE
feat: require Privy authentication for all protected pages

### DIFF
--- a/frontend/app/bridge/page.tsx
+++ b/frontend/app/bridge/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
-import { useRouter } from "next/navigation";
-import { useEffect, useState, useMemo, useRef } from "react";
+import { useState, useMemo, useRef } from "react";
 import { Sidebar } from "../components/sidebar";
 import { RightSidebar } from "../components/right-sidebar";
 import { ThemeToggle } from "../components/themeToggle";
+import { AuthGuard } from "../components/auth-guard";
 import { getTokenIconUrl } from "../utils/token-icons";
 import {
   Aptos,
@@ -44,8 +44,7 @@ const TOKENS = [
 ];
 
 export default function BridgePage() {
-  const { ready, authenticated, user } = usePrivy();
-  const router = useRouter();
+  const { authenticated, user } = usePrivy();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isRightSidebarOpen, setIsRightSidebarOpen] = useState(false);
 
@@ -372,25 +371,8 @@ export default function BridgePage() {
     isValidEthereumAddress(recipientAddress) &&
     !bridging;
 
-  // Show loading while checking authentication status
-  if (!ready) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-        <div className="text-center">
-          <div className="text-lg text-zinc-600 dark:text-zinc-400">
-            Loading...
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Redirect if not authenticated
-  if (!authenticated) {
-    return null;
-  }
-
   return (
+    <AuthGuard>
     <div className="flex h-screen w-full overflow-hidden bg-zinc-50 dark:bg-black">
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
 
@@ -942,5 +924,6 @@ export default function BridgePage() {
         onClose={() => setIsRightSidebarOpen(false)}
       />
     </div>
+    </AuthGuard>
   );
 }

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1,23 +1,22 @@
 "use client";
 
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
-import { useRouter } from "next/navigation";
-import { useEffect, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Sidebar } from "../components/sidebar";
 import { RightSidebar } from "../components/right-sidebar";
 import MovementChat from "../components/chat/MovementChat";
 import { ThemeToggle } from "../components/themeToggle";
+import { AuthGuard } from "../components/auth-guard";
 
 export default function ChatPage() {
-  const { ready, authenticated, user } = usePrivy();
-  const router = useRouter();
+  const { user, authenticated } = usePrivy();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isRightSidebarOpen, setIsRightSidebarOpen] = useState(false);
 
   // Get Movement wallet address (chainType is "aptos" for Movement wallets)
   const movementWallet = useMemo(() => {
-    // Only check for wallet when Privy is ready and user is authenticated
-    if (!ready || !authenticated || !user?.linkedAccounts) {
+    // Only check for wallet when user is authenticated
+    if (!authenticated || !user?.linkedAccounts) {
       return null;
     }
 
@@ -43,8 +42,8 @@ export default function ChatPage() {
         "(should be 66 for Movement Network)"
       );
       console.log("   Chain type:", (aptosWallet as any).chainType);
-    } else if (ready && authenticated) {
-      // Only log warning if we're ready and authenticated but still no wallet found
+    } else if (authenticated) {
+      // Only log warning if authenticated but still no wallet found
       console.log(
         "⚠️ No Movement/Aptos wallet found. Available accounts:",
         user.linkedAccounts.map((acc) => ({
@@ -60,7 +59,7 @@ export default function ChatPage() {
     }
 
     return aptosWallet || null;
-  }, [user, ready, authenticated]);
+  }, [user, authenticated]);
 
   // Get the wallet address - ensure it's the full 66-character Movement/Aptos address
   const walletAddress = useMemo(() => {
@@ -74,66 +73,8 @@ export default function ChatPage() {
     return null;
   }, [movementWallet]);
 
-  // Debug: Log the selected wallet address
-  useEffect(() => {
-    // Only log when Privy is ready and user is authenticated
-    if (!ready || !authenticated) return;
-
-    if (walletAddress) {
-      console.log(
-        "💰 Using Movement wallet address for balance queries:",
-        walletAddress
-      );
-      console.log(
-        "   Address length:",
-        walletAddress.length,
-        "(should be 66 for Movement Network)"
-      );
-    } else {
-      console.warn(
-        "⚠️ No Movement wallet address available. User needs to create a Movement wallet."
-      );
-      if (user?.linkedAccounts) {
-        console.log(
-          "   Available wallets:",
-          user.linkedAccounts
-            .filter((acc) => acc.type === "wallet")
-            .map((acc) => ({
-              chainType: (acc as any).chainType || (acc as any).chain_type,
-              address: `${(acc as any).address?.substring(0, 30)}...`,
-              length: (acc as any).address?.length,
-            }))
-        );
-      }
-    }
-  }, [walletAddress, user, ready, authenticated]);
-
-  // Redirect to home if not authenticated
-  useEffect(() => {
-    if (ready && !authenticated) {
-      router.push("/");
-    }
-  }, [ready, authenticated, router]);
-
-  // Show loading while checking authentication status
-  if (!ready) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-        <div className="text-center">
-          <div className="text-lg text-zinc-600 dark:text-zinc-400">
-            Loading...
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Redirect if not authenticated (handled by useEffect, but show nothing while redirecting)
-  if (!authenticated) {
-    return null;
-  }
-
   return (
+    <AuthGuard>
     <div className="flex h-screen w-full overflow-hidden sm:overflow-hidden bg-zinc-50 dark:bg-black">
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
 
@@ -206,5 +147,6 @@ export default function ChatPage() {
         onClose={() => setIsRightSidebarOpen(false)}
       />
     </div>
+    </AuthGuard>
   );
 }

--- a/frontend/app/components/auth-guard.tsx
+++ b/frontend/app/components/auth-guard.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { useRouter } from "next/navigation";
+import { useEffect, ReactNode } from "react";
+
+interface AuthGuardProps {
+  children: ReactNode;
+  redirectTo?: string;
+}
+
+/**
+ * AuthGuard component that ensures users are authenticated before accessing protected content.
+ * Redirects to the landing page (or specified route) if not authenticated.
+ */
+export function AuthGuard({
+  children,
+  redirectTo = "/",
+}: AuthGuardProps) {
+  const { ready, authenticated } = usePrivy();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (ready && !authenticated) {
+      router.push(redirectTo);
+    }
+  }, [ready, authenticated, router, redirectTo]);
+
+  // Show loading while checking authentication status
+  if (!ready) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-zinc-50 font-sans dark:bg-black">
+        <div className="text-center">
+          <div className="text-lg text-zinc-600 dark:text-zinc-400">
+            Loading...
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // If not authenticated, don't render children (redirect is happening)
+  if (!authenticated) {
+    return null;
+  }
+
+  // User is authenticated, render children
+  return <>{children}</>;
+}
+

--- a/frontend/app/echelon/page.tsx
+++ b/frontend/app/echelon/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
-import { useRouter } from "next/navigation";
 import { useEffect, useState, useMemo } from "react";
 import { Sidebar } from "../components/sidebar";
 import { RightSidebar } from "../components/right-sidebar";
 import { ThemeToggle } from "../components/themeToggle";
+import { AuthGuard } from "../components/auth-guard";
 import { EchelonSupplyModal } from "../components/echelon-supply-modal";
 import { EchelonBorrowModal } from "../components/echelon-borrow-modal";
 import { EchelonWithdrawModal } from "../components/echelon-withdraw-modal";
@@ -70,8 +70,7 @@ const MARKET_TO_SYMBOL: Record<string, string> = {
 };
 
 export default function EchelonPage() {
-  const { ready, authenticated, user } = usePrivy();
-  const router = useRouter();
+  const { authenticated, user } = usePrivy();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
   const [hideZeroBalance, setHideZeroBalance] = useState(false);
@@ -447,25 +446,8 @@ export default function EchelonPage() {
     return assets.filter((a) => a.borrowCap > 0);
   }, [assets]);
 
-  useEffect(() => {
-    if (ready && !authenticated) {
-      router.push("/");
-    }
-  }, [ready, authenticated, router]);
-
-  if (!ready) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-950">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-900 dark:border-zinc-700 dark:border-t-zinc-100" />
-      </div>
-    );
-  }
-
-  if (!authenticated) {
-    return null;
-  }
-
   return (
+    <AuthGuard>
     <div className="flex min-h-screen bg-zinc-50 dark:bg-zinc-950">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
@@ -1158,5 +1140,6 @@ export default function EchelonPage() {
         }}
       />
     </div>
+    </AuthGuard>
   );
 }

--- a/frontend/app/overview/page.tsx
+++ b/frontend/app/overview/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
-import { useRouter } from "next/navigation";
 import { useEffect, useState, useMemo } from "react";
 import { Sidebar } from "../components/sidebar";
 import { RightSidebar } from "../components/right-sidebar";
 import { ThemeToggle } from "../components/themeToggle";
+import { AuthGuard } from "../components/auth-guard";
 import { TransferForm } from "../components/transfer-form";
 import { SwapCard } from "../components/features/swap/SwapCard";
 import { QRCodeSVG } from "qrcode.react";
@@ -24,8 +24,7 @@ interface TokenBalance {
 }
 
 export default function OverviewPage() {
-  const { ready, authenticated, user } = usePrivy();
-  const router = useRouter();
+  const { authenticated, user } = usePrivy();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isRightSidebarOpen, setIsRightSidebarOpen] = useState(false);
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
@@ -41,7 +40,7 @@ export default function OverviewPage() {
   const [tokenPrices, setTokenPrices] = useState<Record<string, number>>({});
 
   const movementWallet = useMemo(() => {
-    if (!ready || !authenticated || !user?.linkedAccounts) {
+    if (!authenticated || !user?.linkedAccounts) {
       return null;
     }
     const aptosWallet = user.linkedAccounts.find(
@@ -54,7 +53,7 @@ export default function OverviewPage() {
       }
     ) as (WalletWithMetadata & { chainType?: string }) | undefined;
     return aptosWallet || null;
-  }, [user, ready, authenticated]);
+  }, [user, authenticated]);
 
   useEffect(() => {
     if (movementWallet?.address) {
@@ -260,24 +259,8 @@ export default function OverviewPage() {
     setShowSwapModal(true);
   };
 
-  if (!ready) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center bg-zinc-50 dark:bg-black font-sans">
-        <div className="text-center">
-          <div className="mb-4 h-12 w-12 animate-spin rounded-full border-4 border-zinc-300 border-t-zinc-900 dark:border-zinc-700 dark:border-t-zinc-100 mx-auto"></div>
-          <div className="text-lg text-zinc-600 dark:text-zinc-400">
-            Loading...
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (!authenticated) {
-    return null;
-  }
-
   return (
+    <AuthGuard>
     <div className="flex h-screen w-full overflow-hidden bg-zinc-50 dark:bg-black">
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
 
@@ -1176,5 +1159,6 @@ export default function OverviewPage() {
         </div>
       )}
     </div>
+    </AuthGuard>
   );
 }

--- a/frontend/app/positions/page.tsx
+++ b/frontend/app/positions/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useState, useMemo, Suspense } from "react";
 import { Sidebar } from "../components/sidebar";
 import { RightSidebar } from "../components/right-sidebar";
 import { ThemeToggle } from "../components/themeToggle";
+import { AuthGuard } from "../components/auth-guard";
 import { SupplyModal } from "../components/supply-modal";
 import { BorrowModal } from "../components/borrow-modal";
 import { getTokenBySymbol, getVerifiedTokens } from "../utils/token-constants";
@@ -114,8 +115,7 @@ interface PortfolioResponse {
 }
 
 function PositionsPageContent() {
-  const { ready, authenticated, user } = usePrivy();
-  const router = useRouter();
+  const { authenticated, user } = usePrivy();
 
   const movementApiBase = getMovementApiBase();
 
@@ -245,12 +245,6 @@ function PositionsPageContent() {
   }, [movementApiBase]);
 
   // Redirect to home if not authenticated
-  useEffect(() => {
-    if (ready && !authenticated) {
-      router.push("/");
-    }
-  }, [ready, authenticated, router]);
-
   const marketPositions: MarketPosition[] = useMemo(() => {
     const verified = getVerifiedTokens();
     // Filter out legacy AptosCoin MOVE (use MOVE-FA instead which has higher utilization)
@@ -343,25 +337,8 @@ function PositionsPageContent() {
   const minRequiredEquityPercent =
     totalCollateral > 0 ? (minRequiredEquity / totalCollateral) * 100 : 0;
 
-  // Show loading while checking authentication status
-  if (!ready) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-        <div className="text-center">
-          <div className="text-lg text-zinc-600 dark:text-zinc-400">
-            Loading...
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Redirect if not authenticated
-  if (!authenticated) {
-    return null;
-  }
-
   return (
+    <AuthGuard>
     <div className="flex h-screen w-full overflow-hidden bg-zinc-50 dark:bg-black">
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
 
@@ -928,6 +905,7 @@ function PositionsPageContent() {
         }}
       />
     </div>
+    </AuthGuard>
   );
 }
 

--- a/frontend/app/premiumchat/page.tsx
+++ b/frontend/app/premiumchat/page.tsx
@@ -1,24 +1,23 @@
 "use client";
 
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
-import { useRouter } from "next/navigation";
-import { useEffect, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Sidebar } from "../components/sidebar";
 import { RightSidebar } from "../components/right-sidebar";
 import PremiumChat from "../components/chat/PremiumChat";
 import { ThemeToggle } from "../components/themeToggle";
+import { AuthGuard } from "../components/auth-guard";
 
 export default function PremiumChatPage() {
-  const { ready, authenticated, user } = usePrivy();
-  const router = useRouter();
+  const { authenticated, user } = usePrivy();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isRightSidebarOpen, setIsRightSidebarOpen] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState("premium_lending");
 
   // Get Movement wallet address (chainType is "aptos" for Movement wallets)
   const movementWallet = useMemo(() => {
-    // Only check for wallet when Privy is ready and user is authenticated
-    if (!ready || !authenticated || !user?.linkedAccounts) {
+    // Only check for wallet when user is authenticated
+    if (!authenticated || !user?.linkedAccounts) {
       return null;
     }
 
@@ -36,7 +35,7 @@ export default function PremiumChatPage() {
     ) as (WalletWithMetadata & { chainType?: string }) | undefined;
 
     return aptosWallet || null;
-  }, [user, ready, authenticated]);
+  }, [user, authenticated]);
 
   // Get the wallet address - ensure it's the full 66-character Movement/Aptos address
   const walletAddress = useMemo(() => {
@@ -50,32 +49,8 @@ export default function PremiumChatPage() {
     return null;
   }, [movementWallet]);
 
-  // Redirect to home if not authenticated
-  useEffect(() => {
-    if (ready && !authenticated) {
-      router.push("/");
-    }
-  }, [ready, authenticated, router]);
-
-  // Show loading while checking authentication status
-  if (!ready) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-        <div className="text-center">
-          <div className="text-lg text-zinc-600 dark:text-zinc-400">
-            Loading...
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Redirect if not authenticated (handled by useEffect, but show nothing while redirecting)
-  if (!authenticated) {
-    return null;
-  }
-
   return (
+    <AuthGuard>
     <div className="flex h-screen w-full overflow-hidden bg-zinc-50 dark:bg-black">
       <Sidebar
         isOpen={isSidebarOpen}
@@ -156,5 +131,6 @@ export default function PremiumChatPage() {
         onClose={() => setIsRightSidebarOpen(false)}
       />
     </div>
+    </AuthGuard>
   );
 }

--- a/frontend/app/swap/page.tsx
+++ b/frontend/app/swap/page.tsx
@@ -1,22 +1,21 @@
 "use client";
 
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
-import { useRouter } from "next/navigation";
-import { useEffect, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Sidebar } from "../components/sidebar";
 import { RightSidebar } from "../components/right-sidebar";
 import { ThemeToggle } from "../components/themeToggle";
 import { SwapCard } from "../components/features/swap";
+import { AuthGuard } from "../components/auth-guard";
 
 export default function SwapPage() {
-  const { ready, authenticated, user } = usePrivy();
-  const router = useRouter();
+  const { authenticated, user } = usePrivy();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isRightSidebarOpen, setIsRightSidebarOpen] = useState(false);
 
   // Get Movement wallet address (chainType is "aptos" for Movement wallets)
   const movementWallet = useMemo(() => {
-    if (!ready || !authenticated || !user?.linkedAccounts) {
+    if (!authenticated || !user?.linkedAccounts) {
       return null;
     }
 
@@ -31,7 +30,7 @@ export default function SwapPage() {
     ) as (WalletWithMetadata & { chainType?: string }) | undefined;
 
     return aptosWallet || null;
-  }, [user, ready, authenticated]);
+  }, [user, authenticated]);
 
   const walletAddress = useMemo(() => {
     if (!movementWallet?.address) return null;
@@ -42,32 +41,8 @@ export default function SwapPage() {
     return null;
   }, [movementWallet]);
 
-  // Redirect to home if not authenticated
-  useEffect(() => {
-    if (ready && !authenticated) {
-      router.push("/");
-    }
-  }, [ready, authenticated, router]);
-
-  // Show loading while checking authentication status
-  if (!ready) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-        <div className="text-center">
-          <div className="text-lg text-zinc-600 dark:text-zinc-400">
-            Loading...
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Redirect if not authenticated
-  if (!authenticated) {
-    return null;
-  }
-
   return (
+    <AuthGuard>
     <div className="flex h-screen w-full overflow-hidden bg-zinc-50 dark:bg-black">
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
 
@@ -141,5 +116,6 @@ export default function SwapPage() {
         onClose={() => setIsRightSidebarOpen(false)}
       />
     </div>
+    </AuthGuard>
   );
 }

--- a/frontend/app/transfer/page.tsx
+++ b/frontend/app/transfer/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
-import { useRouter } from "next/navigation";
 import { useEffect, useState, useMemo, useRef } from "react";
 import { Sidebar } from "../components/sidebar";
 import { RightSidebar } from "../components/right-sidebar";
 import { ThemeToggle } from "../components/themeToggle";
+import { AuthGuard } from "../components/auth-guard";
 import { useSignRawHash } from "@privy-io/react-auth/extended-chains";
 import {
   Aptos,
@@ -43,9 +43,8 @@ interface TokenBalance {
 }
 
 export default function TransferPage() {
-  const { ready, authenticated, user } = usePrivy();
+  const { authenticated, user } = usePrivy();
   const { signRawHash } = useSignRawHash();
-  const router = useRouter();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
   const [recipient, setRecipient] = useState("");
@@ -61,7 +60,7 @@ export default function TransferPage() {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const movementWallet = useMemo(() => {
-    if (!ready || !authenticated || !user?.linkedAccounts) {
+    if (!authenticated || !user?.linkedAccounts) {
       return null;
     }
     return (
@@ -70,13 +69,7 @@ export default function TransferPage() {
           account.type === "wallet" && account.chainType === "aptos"
       ) || null
     );
-  }, [user, ready, authenticated]);
-
-  useEffect(() => {
-    if (ready && !authenticated) {
-      router.push("/");
-    }
-  }, [ready, authenticated, router]);
+  }, [user, authenticated]);
 
   const fetchBalances = async () => {
     if (!movementWallet?.address) {
@@ -301,19 +294,8 @@ export default function TransferPage() {
     }
   };
 
-  if (!ready) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-950">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-900 dark:border-zinc-700 dark:border-t-zinc-100" />
-      </div>
-    );
-  }
-
-  if (!authenticated) {
-    return null;
-  }
-
   return (
+    <AuthGuard>
     <div className="flex min-h-screen bg-zinc-50 dark:bg-zinc-950">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
@@ -771,5 +753,6 @@ export default function TransferPage() {
         onClose={() => setRightSidebarOpen(false)}
       />
     </div>
+    </AuthGuard>
   );
 }


### PR DESCRIPTION
- Add reusable AuthGuard component for authentication protection
- Wrap all protected pages (chat, premiumchat, swap, transfer, bridge, overview, positions, echelon) with AuthGuard
- Ensure users must login with Privy before accessing any functionality
- Remove duplicate authentication checks from individual pages
- Improve code maintainability with centralized auth logic