### PR TITLE
feat: centralize MovePosition operations and hide success messages af…

### DIFF
--- a/frontend/app/components/bridge/BridgeForm.tsx
+++ b/frontend/app/components/bridge/BridgeForm.tsx
@@ -46,6 +46,7 @@ export default function BridgeForm({ walletAddress }: BridgeFormProps) {
   const [bridging, setBridging] = useState(false);
   const [bridgeStep, setBridgeStep] = useState<string | null>(null);
   const [bridgeTxHash, setBridgeTxHash] = useState<string | null>(null);
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const [showTokenDropdown, setShowTokenDropdown] = useState(false);
   const [balance, setBalance] = useState<string | null>(null);
   const [loadingBalance, setLoadingBalance] = useState(false);
@@ -135,8 +136,12 @@ export default function BridgeForm({ walletAddress }: BridgeFormProps) {
 
       setBridgeStep("Transaction submitted...");
       setBridgeTxHash(txHash);
-      setAmount("");
-      setRecipientAddress("");
+      setShowSuccessMessage(true);
+      setTimeout(() => {
+        setShowSuccessMessage(false);
+        setAmount("");
+        setRecipientAddress("");
+      }, 250);
       setBridgeStep(null);
     } catch (error) {
       console.error("Bridge error:", error);
@@ -388,7 +393,9 @@ export default function BridgeForm({ walletAddress }: BridgeFormProps) {
           </div>
 
           {/* Success Message */}
-          {bridgeTxHash && <TransactionSuccessMessage txHash={bridgeTxHash} />}
+          {bridgeTxHash && showSuccessMessage && (
+            <TransactionSuccessMessage txHash={bridgeTxHash} />
+          )}
 
           {/* Bridge Button */}
           <button

--- a/frontend/app/components/echelon-borrow-modal.tsx
+++ b/frontend/app/components/echelon-borrow-modal.tsx
@@ -70,13 +70,12 @@ export function EchelonBorrowModal({
       if (onSuccess) {
         onSuccess();
       }
-      // Reset after showing success
+      // Reset after showing success (250ms)
       setTimeout(() => {
+        setShowSuccessMessage(false);
         setAmount("");
         setPercentage(0);
-        setShowSuccessMessage(false);
-        borrow.resetState();
-      }, 2500);
+      }, 250);
     },
   });
 
@@ -407,7 +406,9 @@ export function EchelonBorrowModal({
         )}
 
         {/* Success Message */}
-        {borrow.txHash && <TransactionSuccessMessage txHash={borrow.txHash} />}
+        {borrow.txHash && showSuccessMessage && (
+          <TransactionSuccessMessage txHash={borrow.txHash} />
+        )}
 
         {/* Borrow Button */}
         <button

--- a/frontend/app/components/echelon-repay-modal.tsx
+++ b/frontend/app/components/echelon-repay-modal.tsx
@@ -36,20 +36,21 @@ export function EchelonRepayModal({
 }: EchelonRepayModalProps) {
   const [amount, setAmount] = useState("");
   const [percentage, setPercentage] = useState(0);
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
 
   // Use centralized repay hook
   const repay = useEchelonRepay({
     onSuccess: () => {
+      setShowSuccessMessage(true);
       if (onSuccess) {
         onSuccess();
       }
-      // Close modal after a delay
+      // Hide success message after 250ms
       setTimeout(() => {
-        onClose();
+        setShowSuccessMessage(false);
         setAmount("");
         setPercentage(0);
-        repay.resetState();
-      }, 2000);
+      }, 250);
     },
   });
 
@@ -287,7 +288,9 @@ export function EchelonRepayModal({
           )}
 
           {/* Success Message */}
-          {repay.txHash && <TransactionSuccessMessage txHash={repay.txHash} />}
+          {repay.txHash && showSuccessMessage && (
+            <TransactionSuccessMessage txHash={repay.txHash} />
+          )}
 
           {/* Repay Button */}
           <button

--- a/frontend/app/components/echelon-supply-modal.tsx
+++ b/frontend/app/components/echelon-supply-modal.tsx
@@ -73,13 +73,12 @@ export function EchelonSupplyModal({
       if (onSuccess) {
         onSuccess();
       }
-      // Reset after showing success
+      // Reset after showing success (250ms)
       setTimeout(() => {
+        setShowSuccessMessage(false);
         setAmount("");
         setPercentage(0);
-        setShowSuccessMessage(false);
-        supply.resetState();
-      }, 2500);
+      }, 250);
     },
   });
 
@@ -289,7 +288,9 @@ export function EchelonSupplyModal({
         )}
 
         {/* Success Message */}
-        {supply.txHash && <TransactionSuccessMessage txHash={supply.txHash} />}
+        {supply.txHash && showSuccessMessage && (
+          <TransactionSuccessMessage txHash={supply.txHash} />
+        )}
 
         {/* Supply Button */}
         <button

--- a/frontend/app/components/echelon-withdraw-modal.tsx
+++ b/frontend/app/components/echelon-withdraw-modal.tsx
@@ -40,13 +40,12 @@ export function EchelonWithdrawModal({
       if (onSuccess) {
         onSuccess();
       }
-      // Reset after showing success
+      // Reset after showing success (250ms)
       setTimeout(() => {
+        setShowSuccessMessage(false);
         setAmount("");
         setPercentage(0);
-        setShowSuccessMessage(false);
-        withdraw.resetState();
-      }, 2500);
+      }, 250);
     },
   });
 
@@ -251,7 +250,7 @@ export function EchelonWithdrawModal({
           )}
 
           {/* Success Message */}
-          {withdraw.txHash && (
+          {withdraw.txHash && showSuccessMessage && (
             <TransactionSuccessMessage txHash={withdraw.txHash} />
           )}
 

--- a/frontend/app/components/features/swap/SwapCard.tsx
+++ b/frontend/app/components/features/swap/SwapCard.tsx
@@ -83,6 +83,7 @@ export const SwapCard: React.FC<SwapCardProps> = ({
   const [fromBalance, setFromBalance] = useState<string | null>(null);
   const [toBalance, setToBalance] = useState<string | null>(null);
   const [loadingFromBalance, setLoadingFromBalance] = useState(false);
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const [loadingToBalance, setLoadingToBalance] = useState(false);
   const [loadingQuote, setLoadingQuote] = useState(false);
   const [quote, setQuote] = useState<MosaicQuoteResponse | null>(null);
@@ -142,9 +143,13 @@ export const SwapCard: React.FC<SwapCardProps> = ({
     aptos,
     movementChainId,
     onSuccess: () => {
-      setFromAmount("");
-      setToAmount("");
-      setQuote(null);
+      setShowSuccessMessage(true);
+      setTimeout(() => {
+        setShowSuccessMessage(false);
+        setFromAmount("");
+        setToAmount("");
+        setQuote(null);
+      }, 250);
     },
   });
 
@@ -645,7 +650,9 @@ export const SwapCard: React.FC<SwapCardProps> = ({
           )}
 
           {/* Success Message */}
-          {swap.txHash && <TransactionSuccessMessage txHash={swap.txHash} />}
+          {swap.txHash && showSuccessMessage && (
+            <TransactionSuccessMessage txHash={swap.txHash} />
+          )}
 
           {/* Swap Button */}
           <button

--- a/frontend/app/components/supply-modal.tsx
+++ b/frontend/app/components/supply-modal.tsx
@@ -11,6 +11,9 @@ import { executeLendV2, executeRedeemV2 } from "../utils/lend-v2-utils";
 import * as superJsonApiClient from "../../lib/super-json-api-client/src";
 import { getMovementApiBase } from "@/lib/super-aptos-sdk/src/globals";
 import { selectBroker, validateBroker } from "../utils/broker-selection";
+import { useMovePositionSupply } from "../hooks/useMovePositionSupply";
+import { useMovePositionWithdraw } from "../hooks/useMovePositionWithdraw";
+import { TransactionSuccessMessage } from "./shared/TransactionSuccessMessage";
 
 // Utility functions for formatting (matching MovePosition's format.ts)
 function prettyTokenBal(num: number): string {
@@ -189,9 +192,6 @@ export function SupplyModal({
   const [showMore, setShowMore] = useState(false);
   const [balance, setBalance] = useState<string | null>(null);
   const [loadingBalance, setLoadingBalance] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [txHash, setTxHash] = useState<string | null>(null);
   const [portfolioData, setPortfolioData] = useState<PortfolioResponse | null>(
     null
   );
@@ -201,35 +201,103 @@ export function SupplyModal({
   const [simulatedRiskData, setSimulatedRiskData] = useState<any | null>(null);
   const [loadingSimulation, setLoadingSimulation] = useState(false);
   const [loadingPortfolio, setLoadingPortfolio] = useState(false);
-  const [submissionStep, setSubmissionStep] = useState<string>("");
-  const [showTxHashOnButton, setShowTxHashOnButton] = useState(false);
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
+
+  // Use centralized hooks for supply and withdraw
+  const supply = useMovePositionSupply({
+    onSuccess: () => {
+      setShowSuccessMessage(true);
+      if (walletAddress) {
+        refreshPortfolioData();
+      }
+    },
+    onError: (error) => {
+      console.error("Supply error:", error);
+    },
+  });
+
+  const withdraw = useMovePositionWithdraw({
+    onSuccess: () => {
+      setShowSuccessMessage(true);
+      if (walletAddress) {
+        refreshPortfolioData();
+      }
+    },
+    onError: (error) => {
+      console.error("Withdraw error:", error);
+    },
+  });
+
+  // Local validation error state (for pre-hook validation)
+  const [validationError, setValidationError] = useState<string | null>(null);
+  // Local state to control button "Transaction Complete" display (250ms delay)
+  const [showButtonComplete, setShowButtonComplete] = useState(false);
+
+  // Determine which hook to use based on active tab
+  const currentOperation = activeTab === "supply" ? supply : withdraw;
+  const submitting =
+    activeTab === "supply" ? supply.supplying : withdraw.withdrawing;
+  const submitError = validationError || currentOperation.error;
+  const txHash = currentOperation.txHash;
+  const submissionStep = currentOperation.step;
 
   const movementApiBase = getMovementApiBase();
 
   const movementWallet = useMovementWallet();
+
+  // Refresh portfolio data function
+  const refreshPortfolioData = async () => {
+    if (!walletAddress) return;
+    try {
+      const superClient = new superJsonApiClient.SuperClient({
+        BASE: movementApiBase,
+      });
+      const [portfolioRes, brokersRes] = await Promise.all([
+        superClient.default.getPortfolio(walletAddress),
+        superClient.default.getBrokers(),
+      ]);
+      setPortfolioData(portfolioRes as unknown as PortfolioResponse);
+      setBrokerData(brokersRes as unknown as any[]);
+    } catch (error) {
+      console.error("Error refreshing portfolio:", error);
+    }
+  };
 
   useEffect(() => {
     if (!isOpen) {
       setAmount("");
       setShowMore(false);
       setActiveTab("supply");
-      setSubmitError(null);
-      setTxHash(null);
-      setSubmissionStep("");
+      // Reset hooks will be handled by the hooks themselves
       setSimulatedRiskData(null);
       setShowSuccessMessage(false);
+      setShowButtonComplete(false);
       return;
     }
   }, [isOpen]);
 
+  // Show "Transaction Complete" on button and TransactionSuccessMessage for 250ms, then reset
+  useEffect(() => {
+    if (txHash && !showButtonComplete) {
+      setShowButtonComplete(true);
+      setShowSuccessMessage(true);
+      const timer = setTimeout(() => {
+        setShowButtonComplete(false);
+        setShowSuccessMessage(false);
+        setAmount("");
+        // Note: txHash remains in hook state but UI elements are hidden
+      }, 250);
+
+      return () => clearTimeout(timer);
+    }
+  }, [txHash, showButtonComplete]);
+
   const handleTabSwitch = (tab: "supply" | "withdraw") => {
     setActiveTab(tab);
     setAmount("");
-    setSubmitError(null);
-    setTxHash(null);
-    setSubmissionStep("");
+    // Reset hooks will be handled by the hooks themselves
     setSimulatedRiskData(null);
+    setShowButtonComplete(false);
   };
 
   useEffect(() => {
@@ -1063,40 +1131,43 @@ export function SupplyModal({
   }, [activeTab, balance, userSuppliedAmount]);
 
   const handleSubmit = async () => {
+    // Clear validation errors
+    setValidationError(null);
+
     // Validate Privy wallet connection
     if (!ready || !authenticated) {
-      setSubmitError("Please connect your Privy wallet first");
+      setValidationError("Please connect your Privy wallet first");
       return;
     }
 
     if (!movementWallet || !walletAddress || !asset) {
-      setSubmitError(
+      setValidationError(
         "Privy wallet not connected. Please connect your Movement wallet."
       );
       return;
     }
 
     if (!amount || parseFloat(amount) <= 0) {
-      setSubmitError("Please enter a valid amount");
+      setValidationError("Please enter a valid amount");
       return;
     }
 
     if (activeTab === "supply") {
       if (balance && parseFloat(amount) > parseFloat(balance)) {
-        setSubmitError("Insufficient balance");
+        setValidationError("Insufficient balance");
         return;
       }
 
       // Check deposit limits before submission (matching MovePosition's validation)
       if (overBrokerDepositLimit) {
-        setSubmitError(
+        setValidationError(
           `Amount exceeds max deposit value set for ${asset.symbol} by broker`
         );
         return;
       }
 
       if (poolIsFull) {
-        setSubmitError(
+        setValidationError(
           `${asset.symbol} pool is full. Pool limits are set by the broker and can be adjusted.`
         );
         return;
@@ -1111,11 +1182,11 @@ export function SupplyModal({
           : 0;
 
         if (userSuppliedAmount < availableLiquidity) {
-          setSubmitError(
+          setValidationError(
             `Amount exceeds your supplied balance of ${asset.symbol}`
           );
         } else {
-          setSubmitError(
+          setValidationError(
             `Amount exceeds available liquidity for ${asset.symbol} in broker`
           );
         }
@@ -1125,9 +1196,9 @@ export function SupplyModal({
       // Also check health factor (matching MovePosition's simHealthRed check)
       if (simHealthRed) {
         if (isSimUnhealthy) {
-          setSubmitError("Withdrawal would make your portfolio unhealthy");
+          setValidationError("Withdrawal would make your portfolio unhealthy");
         } else {
-          setSubmitError(
+          setValidationError(
             "Withdrawal would put your position near liquidation threshold"
           );
         }
@@ -1135,97 +1206,14 @@ export function SupplyModal({
       }
     }
 
-    setSubmitting(true);
-    setSubmitError(null);
-    setTxHash(null);
-    setSubmissionStep("Initializing transaction with Privy...");
-
-    try {
-      const senderAddress = movementWallet.address as string;
-      const senderPubKeyWithScheme = (movementWallet as any)
-        .publicKey as string;
-
-      if (!senderPubKeyWithScheme || senderPubKeyWithScheme.length < 2) {
-        throw new Error("Invalid public key format");
-      }
-
-      // Privy public key format: "004a4b8e35..." (starts with "00", not "0x")
-      // Pass it as-is, the utility will handle the formatting
-      const publicKey = senderPubKeyWithScheme;
-
-      // Convert amount to smallest unit using shared utility
-      const decimals = getCoinDecimals(asset.symbol);
-      const rawAmount = convertAmountToRaw(amount, decimals);
-
-      // Execute transaction using the same approach as scripts
-      const txHash = await (
-        activeTab === "supply" ? executeLendV2 : executeRedeemV2
-      )({
-        amount: rawAmount,
-        coinSymbol: asset.symbol,
-        walletAddress: senderAddress,
-        publicKey,
-        signHash: async (hash: string) => {
-          setSubmissionStep("Waiting for Privy wallet signature...");
-          try {
-            const response = await signRawHash({
-              address: senderAddress,
-              chainType: "aptos",
-              hash: hash as `0x${string}`,
-            });
-            setSubmissionStep("Signature received from Privy");
-            return { signature: response.signature };
-          } catch (error: any) {
-            setSubmissionStep("");
-            throw new Error(
-              error.message || "Failed to get signature from Privy wallet"
-            );
-          }
-        },
-        onProgress: (step: string) => {
-          setSubmissionStep(step);
-        },
-      });
-
-      console.log(
-        `${activeTab === "supply" ? "Supply" : "Withdraw"} transaction successful:`,
-        txHash
-      );
-      setTxHash(txHash);
-      setShowSuccessMessage(true);
-
-      // Refresh portfolio data to update supplied amounts
-      if (walletAddress) {
-        try {
-          const superClient = new superJsonApiClient.SuperClient({
-            BASE: "https://api.moveposition.xyz",
-          });
-          const [portfolioRes, brokersRes] = await Promise.all([
-            superClient.default.getPortfolio(walletAddress),
-            superClient.default.getBrokers(),
-          ]);
-          setPortfolioData(portfolioRes as unknown as PortfolioResponse);
-          setBrokerData(brokersRes as unknown as any[]);
-        } catch (error) {
-          console.error("Error refreshing portfolio:", error);
-        }
-      }
-
-      // Show explorer link on button for 250ms, then reset to initial state
-      setTimeout(() => {
-        setShowSuccessMessage(false);
-        setTxHash(null);
-        setAmount("");
-      }, 250);
-    } catch (err: any) {
-      debugger;
-      console.error("Transaction error:", err);
-      setSubmitError(
-        err.message ||
-          "Transaction failed. Please check your connection and try again."
-      );
-    } finally {
-      setSubmitting(false);
+    // Use the appropriate hook based on active tab
+    if (activeTab === "supply") {
+      const balanceNum = balance ? parseFloat(balance) : undefined;
+      await supply.handleSupply(asset, amount, balanceNum);
+    } else {
+      const maxWithdraw =
+        maxWithdrawableAmount > 0 ? maxWithdrawableAmount : undefined;
+      await withdraw.handleWithdraw(asset, amount, maxWithdraw);
     }
   };
 
@@ -1721,10 +1709,16 @@ export function SupplyModal({
           )}
 
           {/* Transaction Error Message */}
+          {/* Error Message */}
           {submitError && (
             <div className="mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-sm text-red-700 dark:text-red-400">
               {submitError}
             </div>
+          )}
+
+          {/* Success Message */}
+          {txHash && showSuccessMessage && (
+            <TransactionSuccessMessage txHash={txHash} />
           )}
 
           {/* Submit Button */}
@@ -1741,7 +1735,7 @@ export function SupplyModal({
                   : "bg-zinc-300 dark:bg-zinc-700 text-zinc-500 dark:text-zinc-400 cursor-not-allowed"
             }`}
           >
-            {txHash && showSuccessMessage ? (
+            {txHash && showButtonComplete ? (
               <span className="flex items-center justify-center gap-2">
                 <svg
                   className="w-5 h-5"
@@ -1756,29 +1750,7 @@ export function SupplyModal({
                     d="M5 13l4 4L19 7"
                   />
                 </svg>
-                Transaction Submitted!
-                <a
-                  href={`https://explorer.movementnetwork.xyz/txn/${txHash}?network=mainnet`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="ml-2 underline hover:opacity-80 flex items-center gap-1"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  View
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                    />
-                  </svg>
-                </a>
+                Transaction Complete
               </span>
             ) : submitting ? (
               <span className="flex items-center justify-center gap-2">
@@ -1802,9 +1774,7 @@ export function SupplyModal({
                   ></path>
                 </svg>
                 {submissionStep ||
-                  (activeTab === "supply"
-                    ? "Initiating Supply..."
-                    : "Initiating Withdraw...")}
+                  (activeTab === "supply" ? "Supplying..." : "Withdrawing...")}
               </span>
             ) : activeTab === "supply" ? (
               <span className="flex items-center justify-center gap-2">

--- a/frontend/app/components/transfer-form.tsx
+++ b/frontend/app/components/transfer-form.tsx
@@ -35,6 +35,7 @@ export const TransferForm: React.FC<TransferFormProps> = ({
   const [toAddress, setToAddress] = useState("");
   const [tokenDropdownOpen, setTokenDropdownOpen] = useState(false);
   const [showQRScanner, setShowQRScanner] = useState(false);
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const hasManuallySelectedToken = useRef(false);
 
@@ -63,6 +64,12 @@ export const TransferForm: React.FC<TransferFormProps> = ({
     aptos,
     movementChainId,
     onSuccess: () => {
+      setShowSuccessMessage(true);
+      setTimeout(() => {
+        setShowSuccessMessage(false);
+        setAmount("");
+        setToAddress("");
+      }, 250);
       onTransferComplete?.();
     },
   });
@@ -420,7 +427,9 @@ export const TransferForm: React.FC<TransferFormProps> = ({
           )}
 
           {/* Success Message */}
-          {txHash && <TransactionSuccessMessage txHash={txHash} />}
+          {txHash && showSuccessMessage && (
+            <TransactionSuccessMessage txHash={txHash} />
+          )}
 
           {/* Transfer Button */}
           <button

--- a/frontend/app/hooks/useMovePositionBorrow.ts
+++ b/frontend/app/hooks/useMovePositionBorrow.ts
@@ -1,0 +1,216 @@
+/**
+ * Custom hook for handling MovePosition borrow transactions
+ * Consolidates borrow logic used across multiple components
+ */
+
+import { useState, useCallback } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useSignRawHash } from "@privy-io/react-auth/extended-chains";
+import { executeBorrowV2 } from "../utils/borrow-v2-utils";
+import {
+  validateMovePositionAmount,
+  validateMovePositionWallet,
+  validateMovePositionAsset,
+  validateMovePositionBorrowingPower,
+} from "../utils/moveposition/validation";
+import { useBalance } from "./useBalanceContext";
+import { useMovementWallet } from "./useMovementWallet";
+import { getCoinDecimals, convertAmountToRaw } from "../utils/token-utils";
+
+interface UseMovePositionBorrowOptions {
+  onSuccess?: () => void;
+  onError?: (error: string) => void;
+}
+
+interface MovePositionBorrowState {
+  borrowing: boolean;
+  error: string | null;
+  txHash: string | null;
+  step: string | null;
+}
+
+/**
+ * Custom hook for handling MovePosition borrow transactions
+ * @param options - Borrow configuration options
+ * @returns Borrow state and handler function
+ */
+export function useMovePositionBorrow({
+  onSuccess,
+  onError,
+}: UseMovePositionBorrowOptions = {}) {
+  const { signRawHash } = useSignRawHash();
+  const { ready, authenticated } = usePrivy();
+  const { refreshBalances } = useBalance();
+  const movementWallet = useMovementWallet();
+
+  const [state, setState] = useState<MovePositionBorrowState>({
+    borrowing: false,
+    error: null,
+    txHash: null,
+    step: null,
+  });
+
+  const handleBorrow = useCallback(
+    async (
+      asset: { symbol: string; token: any },
+      amount: string,
+      availableBalance?: number,
+      availableLiquidity?: number
+    ): Promise<boolean> => {
+      // Reset error state
+      setState((prev) => ({ ...prev, error: null, step: null }));
+
+      // Validate wallet
+      const walletValidation = validateMovePositionWallet(movementWallet);
+      if (!walletValidation.isValid) {
+        const error = walletValidation.error || "Wallet validation failed";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      if (!ready || !authenticated) {
+        const error = "Please authenticate first";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate asset
+      const assetValidation = validateMovePositionAsset(asset);
+      if (!assetValidation.isValid) {
+        const error = assetValidation.error || "Invalid asset";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate amount
+      const numericAmount = parseFloat(amount);
+      const amountValidation = validateMovePositionAmount(
+        numericAmount,
+        undefined,
+        "borrow"
+      );
+      if (!amountValidation.isValid) {
+        const error = amountValidation.error || "Invalid amount";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate borrowing power if provided
+      if (availableBalance !== undefined && availableLiquidity !== undefined) {
+        const borrowingPowerValidation = validateMovePositionBorrowingPower(
+          numericAmount,
+          availableBalance,
+          availableLiquidity
+        );
+        if (!borrowingPowerValidation.isValid) {
+          const error =
+            borrowingPowerValidation.error || "Insufficient borrowing power";
+          setState((prev) => ({ ...prev, error }));
+          onError?.(error);
+          return false;
+        }
+      }
+
+      // Use wallet from hook (already validated)
+      if (!movementWallet) {
+        const error = "Movement wallet not found";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      const walletAddress = movementWallet.address as string;
+      const publicKey = (movementWallet as any).publicKey as string;
+
+      if (!publicKey || publicKey.length < 2) {
+        const error = "Invalid public key format";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Execute borrow
+      setState((prev) => ({
+        ...prev,
+        borrowing: true,
+        error: null,
+        step: "Building transaction...",
+      }));
+
+      try {
+        // Convert amount to raw format
+        const decimals = getCoinDecimals(asset.symbol);
+        const rawAmount = convertAmountToRaw(amount, decimals);
+
+        const result = await executeBorrowV2({
+          amount: rawAmount,
+          coinSymbol: asset.symbol,
+          walletAddress,
+          publicKey,
+          signHash: async (hash: string) => {
+            setState((prev) => ({ ...prev, step: "Waiting for signature..." }));
+            try {
+              const response = await signRawHash({
+                address: walletAddress,
+                chainType: "aptos",
+                hash: hash as `0x${string}`,
+              });
+              setState((prev) => ({ ...prev, step: "Signature received" }));
+              return { signature: response.signature };
+            } catch (error: any) {
+              setState((prev) => ({ ...prev, step: null }));
+              throw new Error(
+                error.message || "Failed to get signature from wallet"
+              );
+            }
+          },
+          onProgress: (step: string) => {
+            setState((prev) => ({ ...prev, step }));
+          },
+        });
+
+        setState((prev) => ({
+          ...prev,
+          borrowing: false,
+          txHash: result ?? null,
+          step: null,
+        }));
+
+        // Refresh balances after successful borrow
+        await refreshBalances();
+
+        onSuccess?.();
+        return true;
+      } catch (error: any) {
+        const errorMessage =
+          error.message || "Borrow transaction failed. Please try again.";
+        setState((prev) => ({
+          ...prev,
+          borrowing: false,
+          error: errorMessage,
+          step: null,
+        }));
+        onError?.(errorMessage);
+        return false;
+      }
+    },
+    [
+      movementWallet,
+      ready,
+      authenticated,
+      signRawHash,
+      refreshBalances,
+      onSuccess,
+      onError,
+    ]
+  );
+
+  return {
+    ...state,
+    handleBorrow,
+  };
+}

--- a/frontend/app/hooks/useMovePositionRepay.ts
+++ b/frontend/app/hooks/useMovePositionRepay.ts
@@ -1,0 +1,198 @@
+/**
+ * Custom hook for handling MovePosition repay transactions
+ * Consolidates repay logic used across multiple components
+ */
+
+import { useState, useCallback } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useSignRawHash } from "@privy-io/react-auth/extended-chains";
+import { executeRepayV2 } from "../utils/borrow-v2-utils";
+import {
+  validateMovePositionAmount,
+  validateMovePositionWallet,
+  validateMovePositionAsset,
+} from "../utils/moveposition/validation";
+import { useBalance } from "./useBalanceContext";
+import { useMovementWallet } from "./useMovementWallet";
+import { getCoinDecimals, convertAmountToRaw } from "../utils/token-utils";
+
+interface UseMovePositionRepayOptions {
+  onSuccess?: () => void;
+  onError?: (error: string) => void;
+}
+
+interface MovePositionRepayState {
+  repaying: boolean;
+  error: string | null;
+  txHash: string | null;
+  step: string | null;
+}
+
+/**
+ * Custom hook for handling MovePosition repay transactions
+ * @param options - Repay configuration options
+ * @returns Repay state and handler function
+ */
+export function useMovePositionRepay({
+  onSuccess,
+  onError,
+}: UseMovePositionRepayOptions = {}) {
+  const { signRawHash } = useSignRawHash();
+  const { ready, authenticated } = usePrivy();
+  const { refreshBalances } = useBalance();
+  const movementWallet = useMovementWallet();
+
+  const [state, setState] = useState<MovePositionRepayState>({
+    repaying: false,
+    error: null,
+    txHash: null,
+    step: null,
+  });
+
+  const handleRepay = useCallback(
+    async (
+      asset: { symbol: string; token: any },
+      amount: string,
+      availableBalance?: number
+    ): Promise<boolean> => {
+      // Reset error state
+      setState((prev) => ({ ...prev, error: null, step: null }));
+
+      // Validate wallet
+      const walletValidation = validateMovePositionWallet(movementWallet);
+      if (!walletValidation.isValid) {
+        const error = walletValidation.error || "Wallet validation failed";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      if (!ready || !authenticated) {
+        const error = "Please authenticate first";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate asset
+      const assetValidation = validateMovePositionAsset(asset);
+      if (!assetValidation.isValid) {
+        const error = assetValidation.error || "Invalid asset";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate amount
+      const numericAmount = parseFloat(amount);
+      const amountValidation = validateMovePositionAmount(
+        numericAmount,
+        availableBalance,
+        "repay"
+      );
+      if (!amountValidation.isValid) {
+        const error = amountValidation.error || "Invalid amount";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Use wallet from hook (already validated)
+      if (!movementWallet) {
+        const error = "Movement wallet not found";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      const walletAddress = movementWallet.address as string;
+      const publicKey = (movementWallet as any).publicKey as string;
+
+      if (!publicKey || publicKey.length < 2) {
+        const error = "Invalid public key format";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Execute repay
+      setState((prev) => ({
+        ...prev,
+        repaying: true,
+        error: null,
+        step: "Building transaction...",
+      }));
+
+      try {
+        // Convert amount to raw format
+        const decimals = getCoinDecimals(asset.symbol);
+        const rawAmount = convertAmountToRaw(amount, decimals);
+
+        const result = await executeRepayV2({
+          amount: rawAmount,
+          coinSymbol: asset.symbol,
+          walletAddress,
+          publicKey,
+          signHash: async (hash: string) => {
+            setState((prev) => ({ ...prev, step: "Waiting for signature..." }));
+            try {
+              const response = await signRawHash({
+                address: walletAddress,
+                chainType: "aptos",
+                hash: hash as `0x${string}`,
+              });
+              setState((prev) => ({ ...prev, step: "Signature received" }));
+              return { signature: response.signature };
+            } catch (error: any) {
+              setState((prev) => ({ ...prev, step: null }));
+              throw new Error(
+                error.message || "Failed to get signature from wallet"
+              );
+            }
+          },
+          onProgress: (step: string) => {
+            setState((prev) => ({ ...prev, step }));
+          },
+        });
+
+        setState((prev) => ({
+          ...prev,
+          repaying: false,
+          txHash: result ?? null,
+          step: null,
+        }));
+
+        // Refresh balances after successful repay
+        await refreshBalances();
+
+        onSuccess?.();
+        return true;
+      } catch (error: any) {
+        const errorMessage =
+          error.message || "Repay transaction failed. Please try again.";
+        setState((prev) => ({
+          ...prev,
+          repaying: false,
+          error: errorMessage,
+          step: null,
+        }));
+        onError?.(errorMessage);
+        return false;
+      }
+    },
+    [
+      movementWallet,
+      ready,
+      authenticated,
+      signRawHash,
+      refreshBalances,
+      onSuccess,
+      onError,
+    ]
+  );
+
+  return {
+    ...state,
+    handleRepay,
+  };
+}

--- a/frontend/app/hooks/useMovePositionSupply.ts
+++ b/frontend/app/hooks/useMovePositionSupply.ts
@@ -1,0 +1,198 @@
+/**
+ * Custom hook for handling MovePosition supply (lend) transactions
+ * Consolidates supply logic used across multiple components
+ */
+
+import { useState, useCallback } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useSignRawHash } from "@privy-io/react-auth/extended-chains";
+import { executeLendV2 } from "../utils/lend-v2-utils";
+import {
+  validateMovePositionAmount,
+  validateMovePositionWallet,
+  validateMovePositionAsset,
+} from "../utils/moveposition/validation";
+import { useBalance } from "./useBalanceContext";
+import { useMovementWallet } from "./useMovementWallet";
+import { getCoinDecimals, convertAmountToRaw } from "../utils/token-utils";
+
+interface UseMovePositionSupplyOptions {
+  onSuccess?: () => void;
+  onError?: (error: string) => void;
+}
+
+interface MovePositionSupplyState {
+  supplying: boolean;
+  error: string | null;
+  txHash: string | null;
+  step: string | null;
+}
+
+/**
+ * Custom hook for handling MovePosition supply transactions
+ * @param options - Supply configuration options
+ * @returns Supply state and handler function
+ */
+export function useMovePositionSupply({
+  onSuccess,
+  onError,
+}: UseMovePositionSupplyOptions = {}) {
+  const { signRawHash } = useSignRawHash();
+  const { ready, authenticated } = usePrivy();
+  const { refreshBalances } = useBalance();
+  const movementWallet = useMovementWallet();
+
+  const [state, setState] = useState<MovePositionSupplyState>({
+    supplying: false,
+    error: null,
+    txHash: null,
+    step: null,
+  });
+
+  const handleSupply = useCallback(
+    async (
+      asset: { symbol: string; token: any },
+      amount: string,
+      availableBalance?: number
+    ): Promise<boolean> => {
+      // Reset error state
+      setState((prev) => ({ ...prev, error: null, step: null }));
+
+      // Validate wallet
+      const walletValidation = validateMovePositionWallet(movementWallet);
+      if (!walletValidation.isValid) {
+        const error = walletValidation.error || "Wallet validation failed";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      if (!ready || !authenticated) {
+        const error = "Please authenticate first";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate asset
+      const assetValidation = validateMovePositionAsset(asset);
+      if (!assetValidation.isValid) {
+        const error = assetValidation.error || "Invalid asset";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate amount
+      const numericAmount = parseFloat(amount);
+      const amountValidation = validateMovePositionAmount(
+        numericAmount,
+        availableBalance,
+        "supply"
+      );
+      if (!amountValidation.isValid) {
+        const error = amountValidation.error || "Invalid amount";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Use wallet from hook (already validated)
+      if (!movementWallet) {
+        const error = "Movement wallet not found";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      const walletAddress = movementWallet.address as string;
+      const publicKey = (movementWallet as any).publicKey as string;
+
+      if (!publicKey || publicKey.length < 2) {
+        const error = "Invalid public key format";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Execute supply
+      setState((prev) => ({
+        ...prev,
+        supplying: true,
+        error: null,
+        step: "Building transaction...",
+      }));
+
+      try {
+        // Convert amount to raw format
+        const decimals = getCoinDecimals(asset.symbol);
+        const rawAmount = convertAmountToRaw(amount, decimals);
+
+        const result = await executeLendV2({
+          amount: rawAmount,
+          coinSymbol: asset.symbol,
+          walletAddress,
+          publicKey,
+          signHash: async (hash: string) => {
+            setState((prev) => ({ ...prev, step: "Waiting for signature..." }));
+            try {
+              const response = await signRawHash({
+                address: walletAddress,
+                chainType: "aptos",
+                hash: hash as `0x${string}`,
+              });
+              setState((prev) => ({ ...prev, step: "Signature received" }));
+              return { signature: response.signature };
+            } catch (error: any) {
+              setState((prev) => ({ ...prev, step: null }));
+              throw new Error(
+                error.message || "Failed to get signature from wallet"
+              );
+            }
+          },
+          onProgress: (step: string) => {
+            setState((prev) => ({ ...prev, step }));
+          },
+        });
+
+        setState((prev) => ({
+          ...prev,
+          supplying: false,
+          txHash: result ?? null,
+          step: null,
+        }));
+
+        // Refresh balances after successful supply
+        await refreshBalances();
+
+        onSuccess?.();
+        return true;
+      } catch (error: any) {
+        const errorMessage =
+          error.message || "Supply transaction failed. Please try again.";
+        setState((prev) => ({
+          ...prev,
+          supplying: false,
+          error: errorMessage,
+          step: null,
+        }));
+        onError?.(errorMessage);
+        return false;
+      }
+    },
+    [
+      movementWallet,
+      ready,
+      authenticated,
+      signRawHash,
+      refreshBalances,
+      onSuccess,
+      onError,
+    ]
+  );
+
+  return {
+    ...state,
+    handleSupply,
+  };
+}

--- a/frontend/app/hooks/useMovePositionWithdraw.ts
+++ b/frontend/app/hooks/useMovePositionWithdraw.ts
@@ -1,0 +1,198 @@
+/**
+ * Custom hook for handling MovePosition withdraw (redeem) transactions
+ * Consolidates withdraw logic used across multiple components
+ */
+
+import { useState, useCallback } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useSignRawHash } from "@privy-io/react-auth/extended-chains";
+import { executeRedeemV2 } from "../utils/lend-v2-utils";
+import {
+  validateMovePositionAmount,
+  validateMovePositionWallet,
+  validateMovePositionAsset,
+} from "../utils/moveposition/validation";
+import { useBalance } from "./useBalanceContext";
+import { useMovementWallet } from "./useMovementWallet";
+import { getCoinDecimals, convertAmountToRaw } from "../utils/token-utils";
+
+interface UseMovePositionWithdrawOptions {
+  onSuccess?: () => void;
+  onError?: (error: string) => void;
+}
+
+interface MovePositionWithdrawState {
+  withdrawing: boolean;
+  error: string | null;
+  txHash: string | null;
+  step: string | null;
+}
+
+/**
+ * Custom hook for handling MovePosition withdraw transactions
+ * @param options - Withdraw configuration options
+ * @returns Withdraw state and handler function
+ */
+export function useMovePositionWithdraw({
+  onSuccess,
+  onError,
+}: UseMovePositionWithdrawOptions = {}) {
+  const { signRawHash } = useSignRawHash();
+  const { ready, authenticated } = usePrivy();
+  const { refreshBalances } = useBalance();
+  const movementWallet = useMovementWallet();
+
+  const [state, setState] = useState<MovePositionWithdrawState>({
+    withdrawing: false,
+    error: null,
+    txHash: null,
+    step: null,
+  });
+
+  const handleWithdraw = useCallback(
+    async (
+      asset: { symbol: string; token: any },
+      amount: string,
+      availableBalance?: number
+    ): Promise<boolean> => {
+      // Reset error state
+      setState((prev) => ({ ...prev, error: null, step: null }));
+
+      // Validate wallet
+      const walletValidation = validateMovePositionWallet(movementWallet);
+      if (!walletValidation.isValid) {
+        const error = walletValidation.error || "Wallet validation failed";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      if (!ready || !authenticated) {
+        const error = "Please authenticate first";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate asset
+      const assetValidation = validateMovePositionAsset(asset);
+      if (!assetValidation.isValid) {
+        const error = assetValidation.error || "Invalid asset";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Validate amount
+      const numericAmount = parseFloat(amount);
+      const amountValidation = validateMovePositionAmount(
+        numericAmount,
+        availableBalance,
+        "withdraw"
+      );
+      if (!amountValidation.isValid) {
+        const error = amountValidation.error || "Invalid amount";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Use wallet from hook (already validated)
+      if (!movementWallet) {
+        const error = "Movement wallet not found";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      const walletAddress = movementWallet.address as string;
+      const publicKey = (movementWallet as any).publicKey as string;
+
+      if (!publicKey || publicKey.length < 2) {
+        const error = "Invalid public key format";
+        setState((prev) => ({ ...prev, error }));
+        onError?.(error);
+        return false;
+      }
+
+      // Execute withdraw
+      setState((prev) => ({
+        ...prev,
+        withdrawing: true,
+        error: null,
+        step: "Building transaction...",
+      }));
+
+      try {
+        // Convert amount to raw format
+        const decimals = getCoinDecimals(asset.symbol);
+        const rawAmount = convertAmountToRaw(amount, decimals);
+
+        const result = await executeRedeemV2({
+          amount: rawAmount,
+          coinSymbol: asset.symbol,
+          walletAddress,
+          publicKey,
+          signHash: async (hash: string) => {
+            setState((prev) => ({ ...prev, step: "Waiting for signature..." }));
+            try {
+              const response = await signRawHash({
+                address: walletAddress,
+                chainType: "aptos",
+                hash: hash as `0x${string}`,
+              });
+              setState((prev) => ({ ...prev, step: "Signature received" }));
+              return { signature: response.signature };
+            } catch (error: any) {
+              setState((prev) => ({ ...prev, step: null }));
+              throw new Error(
+                error.message || "Failed to get signature from wallet"
+              );
+            }
+          },
+          onProgress: (step: string) => {
+            setState((prev) => ({ ...prev, step }));
+          },
+        });
+
+        setState((prev) => ({
+          ...prev,
+          withdrawing: false,
+          txHash: result ?? null,
+          step: null,
+        }));
+
+        // Refresh balances after successful withdraw
+        await refreshBalances();
+
+        onSuccess?.();
+        return true;
+      } catch (error: any) {
+        const errorMessage =
+          error.message || "Withdraw transaction failed. Please try again.";
+        setState((prev) => ({
+          ...prev,
+          withdrawing: false,
+          error: errorMessage,
+          step: null,
+        }));
+        onError?.(errorMessage);
+        return false;
+      }
+    },
+    [
+      movementWallet,
+      ready,
+      authenticated,
+      signRawHash,
+      refreshBalances,
+      onSuccess,
+      onError,
+    ]
+  );
+
+  return {
+    ...state,
+    handleWithdraw,
+  };
+}

--- a/frontend/app/utils/moveposition/index.ts
+++ b/frontend/app/utils/moveposition/index.ts
@@ -1,0 +1,5 @@
+/**
+ * MovePosition utility exports
+ */
+
+export * from "./validation";

--- a/frontend/app/utils/moveposition/validation.ts
+++ b/frontend/app/utils/moveposition/validation.ts
@@ -1,0 +1,131 @@
+/**
+ * Validation utilities for MovePosition lending protocol operations
+ */
+
+export interface MovePositionValidationResult {
+  isValid: boolean;
+  error?: string;
+  parsedAmount?: number;
+}
+
+/**
+ * Validates amount for MovePosition operations
+ * @param amount - The amount string or number to validate
+ * @param balance - Optional balance to check against
+ * @param operation - Operation type for context
+ * @returns Validation result with parsed amount if valid
+ */
+export function validateMovePositionAmount(
+  amount: string | number,
+  balance?: number | null,
+  operation: "supply" | "withdraw" | "borrow" | "repay" = "supply"
+): MovePositionValidationResult {
+  const numericAmount =
+    typeof amount === "string" ? parseFloat(amount) : amount;
+
+  if (isNaN(numericAmount) || numericAmount <= 0) {
+    return {
+      isValid: false,
+      error: `Please enter a valid amount to ${operation}`,
+    };
+  }
+
+  // Check against balance if provided
+  if (balance !== undefined && balance !== null) {
+    if (numericAmount > balance) {
+      const operationText =
+        operation === "borrow" ? "borrowing power" : "balance";
+      return {
+        isValid: false,
+        error: `Insufficient ${operationText}. Available: ${balance.toFixed(6)}`,
+      };
+    }
+  }
+
+  return {
+    isValid: true,
+    parsedAmount: numericAmount,
+  };
+}
+
+/**
+ * Validates wallet connection for MovePosition operations
+ * @param movementWallet - The movement wallet object
+ * @returns Validation result
+ */
+export function validateMovePositionWallet(
+  movementWallet: any
+): MovePositionValidationResult {
+  if (!movementWallet?.address) {
+    return {
+      isValid: false,
+      error: "Please connect a Movement wallet",
+    };
+  }
+
+  return {
+    isValid: true,
+  };
+}
+
+/**
+ * Validates asset information for MovePosition operations
+ * @param asset - The asset object
+ * @returns Validation result
+ */
+export function validateMovePositionAsset(
+  asset: any
+): MovePositionValidationResult {
+  if (!asset || !asset.symbol) {
+    return {
+      isValid: false,
+      error: "Invalid asset selection",
+    };
+  }
+
+  // Token is optional for MovePosition - only symbol is required for execution
+  // The execute functions (executeLendV2, executeRedeemV2, etc.) work with just the symbol
+
+  return {
+    isValid: true,
+  };
+}
+
+/**
+ * Validates borrowing power for borrow operations
+ * @param amount - The amount to borrow
+ * @param availableBalance - Available borrowing power
+ * @param availableLiquidity - Available liquidity in broker
+ * @returns Validation result
+ */
+export function validateMovePositionBorrowingPower(
+  amount: number,
+  availableBalance: number,
+  availableLiquidity: number
+): MovePositionValidationResult {
+  if (availableBalance <= 0) {
+    return {
+      isValid: false,
+      error:
+        "Insufficient borrowing power. Please supply more assets or repay existing borrows.",
+    };
+  }
+
+  if (amount > availableBalance) {
+    return {
+      isValid: false,
+      error: `Insufficient borrowing power. You can borrow up to ${availableBalance.toFixed(6)} based on your collateral.`,
+    };
+  }
+
+  if (amount > availableLiquidity) {
+    return {
+      isValid: false,
+      error: `Amount exceeds available liquidity. Maximum: ${availableLiquidity.toFixed(6)}`,
+    };
+  }
+
+  return {
+    isValid: true,
+  };
+}


### PR DESCRIPTION
…ter 250ms

- Created centralized hooks for MovePosition operations:
  - useMovePositionSupply: Centralizes supply/lend logic
  - useMovePositionWithdraw: Centralizes withdraw/redeem logic
  - useMovePositionBorrow: Centralizes borrow logic
  - useMovePositionRepay: Centralizes repay logic
- Created validation utilities for MovePosition (utils/moveposition/validation.ts)
- Updated supply-modal.tsx to use centralized hooks
- Updated all transaction components to hide TransactionSuccessMessage after 250ms:
  - Transfer form
  - Swap card
  - Bridge form
  - Echelon supply modal
  - Echelon withdraw modal
  - Echelon borrow modal
  - Echelon repay modal
  - Supply modal (MovePosition)
- Fixed validation to not require token object (only symbol needed)
- Added showSuccessMessage state to control TransactionSuccessMessage visibility
- Consistent 250ms delay before hiding success messages across all components